### PR TITLE
Mention firmware.hex in "Getting Started"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,9 @@ Once connected the script will stop the program running on the micro:bit in
 order to drop you into the REPL itself. You type Python commands next to the
 prompt (``>>>``).
 
+If things don't seem to be working, re-flash your micro:bit using the
+``firmware.hex`` file in this directory, and try again.
+
 You can use the TAB key to auto-complete words. For example, if you
 type ``microbit.sc`` then hit TAB, MicroPython will helpfully complete the
 word for you, like this: ``microbit.screen``.


### PR DESCRIPTION
At least one group hit this problem/solution at the Cambridge Python Users' Group meeting yesterday.  Reflashing with firmware.hex sorted us out, and we felt it ought to be mentioned in the README.  Avoid a common gotcha
