### PR TITLE
Require pyserial 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial
+pyserial < 3.0


### PR DESCRIPTION
It turns out there's an incompatibility between microrepl and pyserial 3.0, so this is the simplest possible workaround.
