### PR TITLE
Enforce upper limit on pyserial dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='http://micropython.org/',
     scripts = ['microrepl.py', ],
     license='apache2',
-    install_requires=['pyserial', ],
+    install_requires=['pyserial<3.0', ],
     package_data={'': ['README.rst', 'CHANGES.rst',
                   'mbedWinSerial_16466.exe']},
     entry_points = {


### PR DESCRIPTION
PySerial 3.0 has a different API to PySerial 2.x; the dependency is correctly reflected in requirements.txt, but not in the setup.py.
