### PR TITLE
Fix Mac OS not detecting micro:bit issue

### DIFF
--- a/microrepl.py
+++ b/microrepl.py
@@ -42,7 +42,7 @@ def find_microbit():
                 return port[0]
     elif platform.startswith('darwin'):
         for port in ports:
-            if 'VID:PID=d28:204' in port[2]:
+            if 'VID:PID=0D28:0204' in port[2]:
                 return port[0]
     elif platform.startswith('win'):
         for port in ports:


### PR DESCRIPTION
Similar issue to a previous commit for Linux, also needs done for Mac OS.
https://github.com/ntoll/microrepl/commit/af5695959c3e47a9bff9b3e8ed490c096f348ac7
