### PR TITLE
Fix miniterm exit character config for PySerial v3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Release History
 ---------------
 
+0.7
++++
+
+Fixed bug #4 when using PySerial version >= 3.0
+
 0.6
 +++
 

--- a/microrepl.py
+++ b/microrepl.py
@@ -20,17 +20,10 @@ MICROBIT_VID = 3368
 BAUDRATE = 115200
 PARITY = 'N'
 ARM = 'https://developer.mbed.org/handbook/Windows-serial-configuration'
+EXIT_CHAR = chr(0x1D)    # GS/CTRL+]
 
 # Regular expression to match the device id of the micro:bit
 RE_VID_PID = re.compile("VID:PID=([0-9A-F]+):([0-9A-F]+)", re.I)
-
-
-if sys.version_info >= (3, 0):
-    def character(b):
-        return b.decode('latin1')
-else:
-    def character(b):
-        return b
 
 
 def find_microbit():
@@ -94,16 +87,15 @@ def main():
     if not port:
         sys.stderr.write('Could not find micro:bit. Is it plugged in?\n')
         sys.exit(0)
-    serial.tools.miniterm.EXITCHARCTER = character(b'\x1d')
     miniterm = connect_miniterm(port)
     # Emit some helpful information about the program and MicroPython.
     shortcut_message = 'Quit: {} | Stop program: Ctrl+C | Reset: Ctrl+D\n'
     help_message = 'Type \'help()\' (without the quotes) then press ENTER.\n'
-    exit_char = key_description(serial.tools.miniterm.EXITCHARCTER)
-    sys.stderr.write(shortcut_message.format(exit_char))
+    sys.stderr.write(shortcut_message.format(key_description(EXIT_CHAR)))
     sys.stderr.write(help_message)
     # Start everything.
     console.setup()
+    miniterm.exit_character = EXIT_CHAR
     miniterm.set_rx_encoding('utf-8')
     miniterm.set_tx_encoding('utf-8')
     miniterm.start()


### PR DESCRIPTION
There was a change on Pyserial v3 how the exit character was configured. It is no longer a module variable, and instead it was moved as member variable the Miniterm class.

That change was made for v3.0a1, so should be safe for all v3 versions: https://github.com/pyserial/pyserial/commit/442bf51bf9fa906b4600d2e99a4b83b8ed26c98e

I originally started this PR as Pyserial v2 and v3 compatible way, but then I realise Microrepl is v3 only, so this fix should be fine for all users.

There is also a bug in the Miniterm constructor that configures this value ( https://github.com/pyserial/pyserial/pull/324), which is why the default wasn't working either. This, and the original, implementation goes around that by setting our own exit character.