### PR TITLE
Remove Console() instance from microrepl

### DIFF
--- a/microrepl.py
+++ b/microrepl.py
@@ -12,8 +12,6 @@ import serial.tools.miniterm
 from serial.tools.list_ports import comports
 from serial.tools.miniterm import Console, Miniterm, key_description
 
-console = Console()
-
 
 MICROBIT_PID = 516
 MICROBIT_VID = 3368
@@ -103,7 +101,6 @@ def main():
     sys.stderr.write(shortcut_message.format(exit_char))
     sys.stderr.write(help_message)
     # Start everything.
-    console.setup()
     miniterm.set_rx_encoding('utf-8')
     miniterm.set_tx_encoding('utf-8')
     miniterm.start()


### PR DESCRIPTION
Pyserial v3 [Miniterm creates its own Console instance](https://github.com/pyserial/pyserial/blob/92d101613be41ecb2f2054c3f43a006fbe6f9966/serial/tools/miniterm.py#L341), so this is no longer needed in microrepl:

Also, having a second Console causes an exception in Windows, this is the causes of issue #16. 