### PR TITLE
Replace magic number PID and VID with module-level definitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Release History
 +++
 
 Fixed bug #4 when using PySerial version >= 3.0
+Fixed issue #16 running on Windows.
 
 0.6
 +++

--- a/microrepl.py
+++ b/microrepl.py
@@ -13,8 +13,8 @@ from serial.tools.list_ports import comports
 from serial.tools.miniterm import Console, Miniterm, key_description
 
 
-MICROBIT_PID = 516
-MICROBIT_VID = 3368
+MICROBIT_PID = 516     # 0x0204
+MICROBIT_VID = 3368    # 0x0D28
 BAUDRATE = 115200
 PARITY = 'N'
 ARM = 'https://developer.mbed.org/handbook/Windows-serial-configuration'
@@ -34,7 +34,7 @@ def find_microbit():
         if match:
             vid, pid = match.groups()
             vid, pid = int(vid, 16), int(pid, 16)
-            if vid == 0x0D28 and pid == 0x0204:
+            if vid == MICROBIT_VID and pid == MICROBIT_PID:
                 return port
     if sys.platform.startswith('win'):
         # No COM port found, so give an informative prompt.


### PR DESCRIPTION
This is a tiny PR really, just replacing the VID and PID magic numbers with the "constants" already defined at the top of the module.

Also added to the changelog a mention to the the fix from #17 (issue #16).