### PR TITLE
Set exit code '1' when there is a port error.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Release History
 
 Fixed bug #4 when using PySerial version >= 3.0
 Fixed issue #16 running on Windows.
+Set the exit code to 1 when microrepl doesn't find a micro:bit serial port. 
 
 0.6
 +++

--- a/microrepl.py
+++ b/microrepl.py
@@ -84,7 +84,7 @@ def main():
     print('port', port)
     if not port:
         sys.stderr.write('Could not find micro:bit. Is it plugged in?\n')
-        sys.exit(0)
+        sys.exit(1)
     miniterm = connect_miniterm(port)
     # Emit some helpful information about the program and MicroPython.
     shortcut_message = 'Quit: {} | Stop program: Ctrl+C | Reset: Ctrl+D\n'


### PR DESCRIPTION
This is really useful when using ufs in a terminal and chaining multiple commands.

At the moment `microrepl` was exiting without marking the error when it wasn't able to find a micro:bit port.