### PR TITLE
Set min pyserial version and remove unnecesary Windows driver installer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Release History
 Fixed bug #4 when using PySerial version >= 3.0
 Fixed issue #16 running on Windows.
 Set pyserial minimum version to 3.0.
+Removed mbedWinSerial_16466.exe driver as is not necessary in the currently
+supported Windows versions.
 
 0.6
 +++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Release History
 
 Fixed bug #4 when using PySerial version >= 3.0
 Fixed issue #16 running on Windows.
+Set pyserial minimum version to 3.0.
 
 0.6
 +++

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.rst
 include CHANGES.rst
-include mbedWinSerial_16466.exe

--- a/README.rst
+++ b/README.rst
@@ -18,19 +18,11 @@ https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop
 Installation
 ------------
 
-Unfortunately, Windows does not come with serial/COM drivers for the micro:bit
-installed by default (happily, Linux and OSX do).
+All currently supported Windows versions (8.1+) should automatically install
+the micro:bit serial/COM drivers when the device is first plugged in.
+All versions of Linux and macOS should work out of the box.
 
-If you're on Windows, in order to make this work you should use the
-mbedWinSerial_16466.exe file (found in the root directory of this project) to
-install the correct drivers. You *MUST* have your micro:bit plugged into your
-computer when you run this command.
-
-For more information and the latest versions of this driver please visit:
-
-https://developer.mbed.org/handbook/Windows-serial-configuration
-
-Assuming this requirement is met, you can install/run the script in three ways:
+You can install/run the script in three ways:
 
 1. Install via pip and PyPI::
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='http://micropython.org/',
     scripts = ['microrepl.py', ],
     license='apache2',
-    install_requires=['pyserial', ],
+    install_requires=['pyserial>=3.0', ],
     package_data={'': ['README.rst', 'CHANGES.rst',
                   'mbedWinSerial_16466.exe']},
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     scripts = ['microrepl.py', ],
     license='apache2',
     install_requires=['pyserial>=3.0', ],
-    package_data={'': ['README.rst', 'CHANGES.rst',
-                  'mbedWinSerial_16466.exe']},
+    package_data={'': ['README.rst', 'CHANGES.rst'},
     entry_points = {
         'console_scripts': [
             'microrepl = microrepl:main',


### PR DESCRIPTION
All supported Windows versions (8.1+) should automatically install the driver when the micro:bit is first plugged in, so the installer is no longer neccesary (it can also interfeer with WebUSB, so installing it is also discouraged).

Also set the pyserial min version to 3.0 as discussed in https://github.com/ntoll/microrepl/pull/8.